### PR TITLE
Add simple AI chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# um100
+# AI Chat Application
+
+This repo contains a simple web-based AI chat interface demonstrating modern chat bubbles, typing indicators and a floating input box. Users can optionally select an avatar image for their messages.
+
+## Usage
+
+Open `web/index.html` in your browser. No server is required.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Chat</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="chat-app">
+        <header class="chat-header">
+            <h1>AI Chat</h1>
+            <label class="avatar-chooser">
+                Choose avatar
+                <input type="file" id="avatarInput" accept="image/*" />
+            </label>
+        </header>
+        <main id="chatWindow" class="chat-window"></main>
+        <form id="chatForm" class="chat-form">
+            <input type="text" id="chatInput" placeholder="Type a message..." autocomplete="off" />
+            <button type="submit">Send</button>
+        </form>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,79 @@
+const chatWindow = document.getElementById('chatWindow');
+const chatForm = document.getElementById('chatForm');
+const chatInput = document.getElementById('chatInput');
+const avatarInput = document.getElementById('avatarInput');
+
+let userAvatarUrl = '';
+
+avatarInput.addEventListener('change', () => {
+    const file = avatarInput.files[0];
+    if (file) {
+        const reader = new FileReader();
+        reader.onload = () => {
+            userAvatarUrl = reader.result;
+        };
+        reader.readAsDataURL(file);
+    }
+});
+
+chatForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = chatInput.value.trim();
+    if (!text) return;
+    addMessage('user', text, userAvatarUrl);
+    chatInput.value = '';
+    showTyping();
+    simulateAiResponse(text).then(reply => {
+        hideTyping();
+        addMessage('bot', reply);
+    });
+});
+
+function addMessage(sender, text, avatar) {
+    const message = document.createElement('div');
+    message.className = `message ${sender}`;
+
+    const avatarDiv = document.createElement('div');
+    avatarDiv.className = 'avatar';
+    if (avatar) {
+        const img = document.createElement('img');
+        img.src = avatar;
+        avatarDiv.appendChild(img);
+    }
+    message.appendChild(avatarDiv);
+
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble';
+    bubble.textContent = text;
+    message.appendChild(bubble);
+
+    chatWindow.appendChild(message);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+let typingMessage;
+function showTyping() {
+    typingMessage = document.createElement('div');
+    typingMessage.className = 'message bot';
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble typing';
+    bubble.textContent = 'AI is typing...';
+    typingMessage.appendChild(document.createElement('div')); // empty avatar
+    typingMessage.appendChild(bubble);
+    chatWindow.appendChild(typingMessage);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+function hideTyping() {
+    if (typingMessage && typingMessage.parentNode) {
+        chatWindow.removeChild(typingMessage);
+    }
+}
+
+function simulateAiResponse(userText) {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve('You said: ' + userText);
+        }, 1000);
+    });
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,124 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    height: 100vh;
+    background: linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.chat-app {
+    width: 100%;
+    max-width: 600px;
+    height: 90vh;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(5px);
+    border-radius: 20px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
+}
+
+.chat-header {
+    padding: 10px 15px;
+    background-color: #ffffffaa;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #ddd;
+}
+
+.avatar-chooser input {
+    display: none;
+}
+
+.avatar-chooser {
+    font-size: 14px;
+    cursor: pointer;
+    padding: 5px 10px;
+    border-radius: 4px;
+    background-color: #f0f0f0;
+}
+
+.chat-window {
+    flex: 1;
+    padding: 15px;
+    overflow-y: auto;
+}
+
+.message {
+    display: flex;
+    margin-bottom: 10px;
+}
+
+.message .avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #ccc;
+    overflow: hidden;
+    margin-right: 10px;
+    flex-shrink: 0;
+}
+
+.message .avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.bubble {
+    padding: 10px 15px;
+    border-radius: 15px;
+    max-width: 70%;
+}
+
+.user .bubble {
+    background-color: #0084ff;
+    color: white;
+    border-bottom-right-radius: 0;
+    margin-left: auto;
+}
+
+.bot .bubble {
+    background-color: #e5e5ea;
+    color: black;
+    border-bottom-left-radius: 0;
+}
+
+.chat-form {
+    position: absolute;
+    bottom: 15px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 30px);
+    display: flex;
+    background-color: #ffffffdd;
+    border-radius: 25px;
+    padding: 5px;
+}
+
+.chat-form input {
+    flex: 1;
+    border: none;
+    padding: 10px;
+    border-radius: 25px;
+    outline: none;
+}
+
+.chat-form button {
+    border: none;
+    background: #0084ff;
+    color: white;
+    padding: 10px 15px;
+    border-radius: 25px;
+    margin-left: 5px;
+    cursor: pointer;
+}
+
+.typing {
+    font-style: italic;
+    opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- add web-based AI chat example
- style with gradient background and chat bubbles
- implement typing indicator and avatar upload
- update README with usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688637f651148327a28b1c38dc7ebc39